### PR TITLE
Fix README.md MindSearch Backend Setup Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Setup FastAPI Server.
 python -m mindsearch.app --lang en --model_format internlm_server
 ```
 
-- `--lang`: language of the model, `en` for English and `zh` for Chinese.
+- `--lang`: language of the model, `en` for English and `cn` for Chinese.
 - `--model_format`: format of the model.
   - `internlm_server` for InternLM2.5-7b-chat with local server. (InternLM2.5-7b-chat has been better optimized for Chinese.)
   - `gpt4` for GPT4.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -54,7 +54,7 @@ pip install -r requirements.txt
 python -m mindsearch.app --lang en --model_format internlm_server
 ```
 
-- `--lang`: 模型的语言，`en` 为英语，`zh` 为中文。
+- `--lang`: 模型的语言，`en` 为英语，`cn` 为中文。
 - `--model_format`: 模型的格式。
   - `internlm_server` 为 InternLM2.5-7b-chat 本地服务器。
   - `gpt4` 为 GPT4。


### PR DESCRIPTION
In https://github.com/InternLM/MindSearch/blob/main/mindsearch/app.py#L21
```python   
parser.add_argument('--lang', default='cn', type=str, help='Language')
```

The default option for Chinese should be `cn` while the README.md says `zh` for Chinese. Therefore, I fixed both `README.md` and `README_zh-CN.md` so that the docs follow the code.