### PR TITLE
Bug: Fix searcher_resp_queue not available sometimes

### DIFF
--- a/mindsearch/agent/mindsearch_agent.py
+++ b/mindsearch/agent/mindsearch_agent.py
@@ -5,6 +5,7 @@ import random
 import re
 import threading
 import uuid
+import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
@@ -366,7 +367,12 @@ class MindSearchAgent(BaseAgent):
 
         while True:
             try:
-                item = self.local_dict.get('graph').searcher_resp_queue.get(
+                graph = self.local_dict.get('graph')
+                if not graph:
+                    print('Initial code not executed yet, waiting...')
+                    time.sleep(1)
+                    continue
+                item = graph.searcher_resp_queue.get(
                     timeout=60)
                 if item is WebSearchGraph.end_signal:
                     for node_name in ordered_nodes:


### PR DESCRIPTION
The `graph` may not be ready when we try to access it for the first time. Sometimes the code returned by LLM (gpt4o for example), especially the first line `graph = WebSearchGraph()`, has not been executed yet. 
This PR adds a retry mechanism when accessing `graph`, which partly fixes issue #36 #17.

![image](https://github.com/user-attachments/assets/428d236c-d9d9-4d7c-8e85-e1e97130253d)
