### PR TITLE
fix 调整openai_api_base的填写格式 和 支持命令行模式下选择搜索引擎

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install -r requirements.txt
 Setup FastAPI Server.
 
 ```bash
-python -m mindsearch.app --lang en --model_format internlm_server
+python -m mindsearch.app --lang en --model_format internlm_server --search_engine DuckDuckGoSearch
 ```
 
 - `--lang`: language of the model, `en` for English and `cn` for Chinese.
@@ -61,6 +61,9 @@ python -m mindsearch.app --lang en --model_format internlm_server
   - `internlm_server` for InternLM2.5-7b-chat with local server. (InternLM2.5-7b-chat has been better optimized for Chinese.)
   - `gpt4` for GPT4.
     if you want to use other models, please modify [models](./mindsearch/agent/models.py)
+- `--search_engine`: Search engine.
+  - `DuckDuckGoSearch` for search engine for DuckDuckGo.
+  - `BingSearch` for Bing search engine.
 
 ### Step3: Setup MindSearch Frontend
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -51,7 +51,7 @@ pip install -r requirements.txt
 启动 FastAPI 服务器
 
 ```bash
-python -m mindsearch.app --lang en --model_format internlm_server
+python -m mindsearch.app --lang en --model_format internlm_server --search_engine DuckDuckGoSearch
 ```
 
 - `--lang`: 模型的语言，`en` 为英语，`cn` 为中文。
@@ -59,7 +59,9 @@ python -m mindsearch.app --lang en --model_format internlm_server
   - `internlm_server` 为 InternLM2.5-7b-chat 本地服务器。
   - `gpt4` 为 GPT4。
     如果您想使用其他模型，请修改 [models](./mindsearch/agent/models.py)
-
+- `--search_engine`: 搜索引擎。
+  - `DuckDuckGoSearch` 为 DuckDuckGo 搜索引擎。
+  - `BingSearch` 为 Bing搜索引擎。
 ### 步骤3: 启动 MindSearch 前端
 
 提供以下几种前端界面：

--- a/mindsearch/agent/__init__.py
+++ b/mindsearch/agent/__init__.py
@@ -17,7 +17,7 @@ from mindsearch.agent.mindsearch_prompt import (
 LLM = {}
 
 
-def init_agent(lang='cn', model_format='internlm_server'):
+def init_agent(lang='cn', model_format='internlm_server',search_engine='DuckDuckGoSearch'):
     llm = LLM.get(model_format, None)
     if llm is None:
         llm_cfg = getattr(llm_factory, model_format)
@@ -43,7 +43,7 @@ def init_agent(lang='cn', model_format='internlm_server'):
         searcher_cfg=dict(
             llm=llm,
             plugin_executor=ActionExecutor(
-                BingBrowser(searcher_type='DuckDuckGoSearch',
+                BingBrowser(searcher_type=search_engine,
                             topk=6,
                             api_key=os.environ.get('BING_API_KEY',
                                                    'YOUR BING API'))),

--- a/mindsearch/agent/models.py
+++ b/mindsearch/agent/models.py
@@ -34,7 +34,7 @@ internlm_hf = dict(type=HFTransformerCasualLM,
                    max_new_tokens=8192,
                    repetition_penalty=1.02,
                    stop_words=['<|im_end|>'])
-# openai_api_base需要填写完整的chat api地址，如：https://api.openai.com/v1/chat/completions
+# openai_api_base needs to fill in the complete chat api address, such as: https://api.openai.com/v1/chat/completions
 gpt4 = dict(type=GPTAPI,
             model_type='gpt-4-turbo',
             key=os.environ.get('OPENAI_API_KEY', 'YOUR OPENAI API KEY'),

--- a/mindsearch/agent/models.py
+++ b/mindsearch/agent/models.py
@@ -34,11 +34,11 @@ internlm_hf = dict(type=HFTransformerCasualLM,
                    max_new_tokens=8192,
                    repetition_penalty=1.02,
                    stop_words=['<|im_end|>'])
-
+# openai_api_base需要填写完整的chat api地址，如：https://api.openai.com/v1/chat/completions
 gpt4 = dict(type=GPTAPI,
             model_type='gpt-4-turbo',
             key=os.environ.get('OPENAI_API_KEY', 'YOUR OPENAI API KEY'),
-            openai_api_base=os.environ.get('OPENAI_API_BASE', 'https://api.openai.com/v1'),
+            openai_api_base=os.environ.get('OPENAI_API_BASE', 'https://api.openai.com/v1/chat/completions'),
             )
 
 url = 'https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation'

--- a/mindsearch/app.py
+++ b/mindsearch/app.py
@@ -23,6 +23,10 @@ def parse_arguments():
                         default='internlm_server',
                         type=str,
                         help='Model format')
+    parse.add_argument('--search_engine',
+                       default='DuckDuckGoSearch',
+                       type=str,
+                       help='Search engine')
     return parser.parse_args()
 
 
@@ -123,7 +127,7 @@ async def run(request: GenerationParams):
             await queue.wait_closed()
 
     inputs = request.inputs
-    agent = init_agent(lang=args.lang, model_format=args.model_format)
+    agent = init_agent(lang=args.lang, model_format=args.model_format,search_engine=args.search_engine)
     return EventSourceResponse(generate())
 
 


### PR DESCRIPTION
主要修复内容：
1. 使用gpt4时指定openai地址的格式，添加说明信息
2. 命令行启动后端服务，可以指定搜索引擎

---
Main repair content:
1. When using gpt4, specify the format of the openai address and add explanatory information
2. Start the backend service from the command line and specify the search engine