### PR TITLE
append griffe==0.48 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sse-starlette
 termcolor
 transformers==4.41.0
 uvicorn
+griffe==0.48


### PR DESCRIPTION
To fix [back end failed to launch on Huggingface due to unexpected griffe version #173
(https://github.com/InternLM/MindSearch/issues/173).