### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ einops
 fastapi
 gradio==5.7.1
 janus
-lagent==0.5.0rc2
+lagent @ git+https://github.com/InternLM/lagent.git
 matplotlib
 pydantic==2.6.4
 python-dotenv


### PR DESCRIPTION
`0.5.0rc2` 版本的lagent调用搜索引擎API会报错，而且问题已经被[后序PR](https://github.com/InternLM/lagent/pull/281)解决。 所以 requirements.txt 指定安装了`0.5.0rc2` 版本的lagent会导致报错，我们要安装这个PR之后的lagent。