### PR TITLE
修正 Qwen 模型调用接口

### DIFF
--- a/mindsearch/agent/models.py
+++ b/mindsearch/agent/models.py
@@ -55,7 +55,7 @@ gpt4 = dict(
                             "https://api.openai.com/v1/chat/completions"),
 )
 
-url = "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
 qwen = dict(
     type=GPTAPI,
     model_type="qwen-max-longcontext",


### PR DESCRIPTION
此接口修正需要和子项目 lagent PR 同时进行， 修改前 lagent 对于千问模型调用将 dashscope 形式的接口与 OpenAI 混用导致出现同步模式下无法解码模型响应的问题。

参考：

[修复 PR](https://github.com/InternLM/lagent/pull/287)
[修复 Issue](https://github.com/InternLM/lagent/issues/286)