### PR TITLE
添加searxng搜索引擎支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ python -m mindsearch.app --lang en --model_format internlm_server --search_engin
   - `BraveSearch` for Brave search web api engine.
   - `GoogleSearch` for Google Serper web search api engine.
   - `TencentSearch` for Tencent search api engine.
+  - `SearxngSearch` for searxng search api engine.
   
   Please set your Web Search engine API key as the `WEB_SEARCH_API_KEY` environment variable unless you are using `DuckDuckGo`, or `TencentSearch` that requires secret id as `TENCENT_SEARCH_SECRET_ID` and secret key as `TENCENT_SEARCH_SECRET_KEY`.
 - `--asy`: deploy asynchronous agents.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -65,6 +65,7 @@ python -m mindsearch.app --lang en --model_format internlm_server --search_engin
   - `BraveSearch` 为 Brave 搜索引擎。
   - `GoogleSearch` 为 Google Serper 搜索引擎。
   - `TencentSearch` 为 Tencent 搜索引擎。
+  - `SearxngSearch` 为 searxng 搜索引擎。
     
   请将 DuckDuckGo 和 Tencent 以外的网页搜索引擎 API 密钥设置为 `WEB_SEARCH_API_KEY` 环境变量。如果使用 DuckDuckGo，则无需设置；如果使用 Tencent，请设置 `TENCENT_SEARCH_SECRET_ID` 和 `TENCENT_SEARCH_SECRET_KEY`。
  


### PR DESCRIPTION
https://github.com/InternLM/lagent/pull/293
支持searxng搜索引擎。
lagent和mindsearch都已测试通过：
python -m mindsearch.app --lang ch --model_format internlm_client --search_engine SearxngSearch --asy