### PR TITLE
【feature】llm添加openai风格服务端支持(自定义代理地址和模型名称)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ python -m mindsearch.app --lang en --model_format internlm_server --search_engin
   - `BraveSearch` for Brave search web api engine.
   - `GoogleSearch` for Google Serper web search api engine.
   - `TencentSearch` for Tencent search api engine.
+  - `SearxngSearch` for searxng search api engine.
   
   Please set your Web Search engine API key as the `WEB_SEARCH_API_KEY` environment variable unless you are using `DuckDuckGo`, or `TencentSearch` that requires secret id as `TENCENT_SEARCH_SECRET_ID` and secret key as `TENCENT_SEARCH_SECRET_KEY`.
 - `--asy`: deploy asynchronous agents.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -65,6 +65,7 @@ python -m mindsearch.app --lang en --model_format internlm_server --search_engin
   - `BraveSearch` 为 Brave 搜索引擎。
   - `GoogleSearch` 为 Google Serper 搜索引擎。
   - `TencentSearch` 为 Tencent 搜索引擎。
+  - `SearxngSearch` 为 searxng 搜索引擎。
     
   请将 DuckDuckGo 和 Tencent 以外的网页搜索引擎 API 密钥设置为 `WEB_SEARCH_API_KEY` 环境变量。如果使用 DuckDuckGo，则无需设置；如果使用 Tencent，请设置 `TENCENT_SEARCH_SECRET_ID` 和 `TENCENT_SEARCH_SECRET_KEY`。
  

--- a/mindsearch/agent/models.py
+++ b/mindsearch/agent/models.py
@@ -2,7 +2,6 @@ import os
 
 from dotenv import load_dotenv
 from lagent.llms import (
-  GPTStyleAPI,
     GPTAPI,
     INTERNLM2_META,
     HFTransformerCasualLM,
@@ -54,17 +53,6 @@ gpt4 = dict(
     key=os.environ.get("OPENAI_API_KEY", "YOUR OPENAI API KEY"),
     api_base=os.environ.get("OPENAI_API_BASE",
                             "https://api.openai.com/v1/chat/completions"),
-)
-api_base = 'http://192.168.26.213:13000/v1/chat/completions' # oneapi
-# model_name =  "Baichuan2-Turbo"
-model_name ="deepseek-r1-14b"
-gptstyle = dict(
-    type=GPTStyleAPI,
-    model_type=model_name,
-    # key=os.environ.get("OPENAI_STYLE_API_KEY", "sk-IXgCTwuoEwxL1CiBE4744688D8094521B70f4aDeE6830c5e"),
-    # api_base=os.environ.get("OPENAI_STYLE_API_BASE",api_base),
-    key="sk-CZOUavQGNzkkQjZr626908A0011040F8B743C526F315D6Ee",
-    api_base=api_base,
 )
 
 url = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"

--- a/mindsearch/agent/models.py
+++ b/mindsearch/agent/models.py
@@ -2,6 +2,7 @@ import os
 
 from dotenv import load_dotenv
 from lagent.llms import (
+  GPTStyleAPI,
     GPTAPI,
     INTERNLM2_META,
     HFTransformerCasualLM,
@@ -53,6 +54,18 @@ gpt4 = dict(
     key=os.environ.get("OPENAI_API_KEY", "YOUR OPENAI API KEY"),
     api_base=os.environ.get("OPENAI_API_BASE",
                             "https://api.openai.com/v1/chat/completions"),
+)
+
+api_base = 'http://192.168.26.213:13000/v1/chat/completions' # oneapi
+# model_name =  "Baichuan2-Turbo"
+model_name ="deepseek-r1-14b"
+gptstyle = dict(
+    type=GPTStyleAPI,
+    model_type=model_name,
+    # key=os.environ.get("OPENAI_STYLE_API_KEY", "sk-IXgCTwuoEwxL1CiBE4744688D8094521B70f4aDeE6830c5e"),
+    # api_base=os.environ.get("OPENAI_STYLE_API_BASE",api_base),
+    key="sk-CZOUavQGNzkkQjZr626908A0011040F8B743C526F315D6Ee",
+    api_base=api_base,
 )
 
 url = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"

--- a/mindsearch/agent/models.py
+++ b/mindsearch/agent/models.py
@@ -2,6 +2,7 @@ import os
 
 from dotenv import load_dotenv
 from lagent.llms import (
+  GPTStyleAPI,
     GPTAPI,
     INTERNLM2_META,
     HFTransformerCasualLM,
@@ -53,6 +54,17 @@ gpt4 = dict(
     key=os.environ.get("OPENAI_API_KEY", "YOUR OPENAI API KEY"),
     api_base=os.environ.get("OPENAI_API_BASE",
                             "https://api.openai.com/v1/chat/completions"),
+)
+api_base = 'http://192.168.26.213:13000/v1/chat/completions' # oneapi
+# model_name =  "Baichuan2-Turbo"
+model_name ="deepseek-r1-14b"
+gptstyle = dict(
+    type=GPTStyleAPI,
+    model_type=model_name,
+    # key=os.environ.get("OPENAI_STYLE_API_KEY", "sk-IXgCTwuoEwxL1CiBE4744688D8094521B70f4aDeE6830c5e"),
+    # api_base=os.environ.get("OPENAI_STYLE_API_BASE",api_base),
+    key="sk-CZOUavQGNzkkQjZr626908A0011040F8B743C526F315D6Ee",
+    api_base=api_base,
 )
 
 url = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"


### PR DESCRIPTION
https://github.com/InternLM/lagent/pull/294
# 使用方法
**PS 如果lagent还未合并该pr。需要手动复制lagent项目294的pr文件，覆盖python安装包lagent路径里面的相应文件。（或者自行打包lagent去安装）**
## mindsearch
- mindsearch\agent\models.py
- 修改api_base 、model_name 、key（如果服务端需要的话）
- 命令行：python -m mindsearch.app --lang ch --model_format gptstyle --search_engine SearxngSearch --asy
```
from lagent.llms import (
  GPTStyleAPI,
    GPTAPI,
    INTERNLM2_META,
    HFTransformerCasualLM,
    LMDeployClient,
    LMDeployServer,
)
api_base = 'http://192.168.26.213:13000/v1/chat/completions' # oneapi
# model_name =  "Baichuan2-Turbo"
model_name ="deepseek-r1-14b"
gptstyle = dict(
    type=GPTStyleAPI,
    model_type=model_name,
    # key=os.environ.get("OPENAI_STYLE_API_KEY", "sk-IXgCTwuoEwxL1CiBE4744688D8094521B70f4aDeE6830c5e"),
    # api_base=os.environ.get("OPENAI_STYLE_API_BASE",api_base),
    key="sk-CZOUavQGNzkkQjZr626908A0011040F8B743C526F315D6Ee",
    api_base=api_base,
)
```
**PS:  INTERNLM似乎有做适配改造。ds-14b有自己的逻辑，似乎不适合mindsearch**
oneapi测试通过如下：
![1738834592259](https://github.com/user-attachments/assets/1e178035-e18a-4cc6-a029-7e57879dfa19)

